### PR TITLE
Remove addClass for vanilla js classList.add('class-name')

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,9 +49,9 @@ module.exports = {
         lightbox_base_element	= document.createElement('DIV');
         lightbox_img_element	= document.createElement('IMG');
         
-        lightbox_base_element.addClass('ui-lightbox-image');
-        lightbox_background.addClass('ui-lightbox-image-bg');
-        lightbox_img_element.addClass('ui-lightbox-image-img');
+        lightbox_base_element.classList.add('ui-lightbox-image');
+        lightbox_background.classList.add('ui-lightbox-image-bg');
+        lightbox_img_element.classList.add('ui-lightbox-image-img');
 
 		lightbox_base_element.setAttribute('id', 		'ui-lightbox-image');
 		lightbox_background.setAttribute('id', 			'ui-lightbox-image-bg');


### PR DESCRIPTION
Hi, the addClass method gives an js error, so changed this to use the use DOM-node's classList instead